### PR TITLE
login_required decorator for Django view

### DIFF
--- a/ariadne_django_ext/decorators.py
+++ b/ariadne_django_ext/decorators.py
@@ -1,5 +1,16 @@
 from functools import wraps
 
+from .utils import is_authenticated
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        if is_authenticated(request):
+            return view(request, *args, **kwargs)
+
+    return wrapper
+
 
 def wrap_result(key: str):
     def wrap_resolver(resolver):

--- a/ariadne_django_ext/utils.py
+++ b/ariadne_django_ext/utils.py
@@ -1,0 +1,8 @@
+from django.core.exceptions import PermissionDenied
+
+
+def is_authenticated(request):
+    user = getattr(request, "user")
+    if user and user.is_authenticated and user.is_active:
+        return user
+    raise PermissionDenied()


### PR DESCRIPTION
login_required decorator raises PermissionDenied instead of redirecting to LOGIN_URL